### PR TITLE
fix: commerceconnector title prop

### DIFF
--- a/composable-ui/src/components/cms/commerce-connector.tsx
+++ b/composable-ui/src/components/cms/commerce-connector.tsx
@@ -3,7 +3,7 @@ import { ProductCard } from '@composable/ui'
 import { useRouter } from 'next/router'
 
 export interface GenericConnectorProps {
-  sectionTitle?: string
+  title?: string
   ctaLabel?: string
   ctaHref?: string
   ctaHeight?: string
@@ -30,7 +30,7 @@ export interface PriceProps {
 
 export const CommerceConnector = (props: GenericConnectorProps) => {
   const {
-    sectionTitle,
+    title,
     ctaLabel,
     ctaHref,
     products,
@@ -48,8 +48,8 @@ export const CommerceConnector = (props: GenericConnectorProps) => {
         <Flex
           gap={{ base: '0.5rem', md: '0.625rem' }}
           mb={{
-            base: sectionTitle && ctaHref ? '8' : undefined,
-            md: sectionTitle && ctaHref ? '12' : undefined,
+            base: title && ctaHref ? '8' : undefined,
+            md: title && ctaHref ? '12' : undefined,
           }}
           justifyContent={'space-between'}
         >
@@ -58,7 +58,7 @@ export const CommerceConnector = (props: GenericConnectorProps) => {
             textStyle={{ base: 'Body-L', md: 'Body-XL' }}
             color={'primary'}
           >
-            {sectionTitle}
+            {title}
           </Text>
           {ctaLabel && ctaHref && (
             <Button onClick={() => router.push(ctaHref)}>{ctaLabel}</Button>

--- a/packages/cms-generic/src/data/pages.json
+++ b/packages/cms-generic/src/data/pages.json
@@ -201,8 +201,6 @@
         "containerMarginBottom": "5",
         "containerMarginTop": "5",
         "containerSize": "full",
-        "ctaMaxWidth": "362px",
-        "ctaMinWidth": "290px",
         "id": "44968ea0-70f9-494f-b88c-d7ffe4804597",
         "products": [
           {
@@ -269,8 +267,7 @@
             },
             "slug": "casual-short-sleeve-dress-in-bone"
           }
-        ],
-        "title": "Women collections"
+        ]
       },
       {
         "__typename": "BannerTextOnly",


### PR DESCRIPTION
## Background

Fixed misalignment with the commerce connector component. The base definition was expecting `sectionTitle`, but `title` was being provided. `title` is in line with other component type definitions, so I've updated the commerce connector to have a `title`. 

Also cleaned up the static home page data, which was providing a `title` in the commerce connector component. It wasn't previous displaying due to this bug, and now that the bug is fixed, it's not necessary as a header and subheader are being provided for the featured product collection through a `bannerTextOnly`. I also removed the `ctaMinWidth` and `ctaMaxWidth` because there was no CTA provided for this component, making them unnecessary. 
