### PR TITLE
fix: updated TextCard image sizes and spacing in Account Drawer

### DIFF
--- a/composable-ui/src/components/forms/login-form.tsx
+++ b/composable-ui/src/components/forms/login-form.tsx
@@ -288,7 +288,9 @@ export const LoginForm = ({
                     paddingTop={10}
                     spacing={6}
                   >
-                    <Text textStyle={'Desktop/M'}>{content.notAMemberYet}</Text>
+                    <Text textStyle={'Desktop/M'} pt={2} pb={4}>
+                      {content.notAMemberYet}
+                    </Text>
                     <Button
                       size={{ base: 'md', md: 'lg' }}
                       variant={'outline'}

--- a/packages/ui/src/components/cms/text-card.tsx
+++ b/packages/ui/src/components/cms/text-card.tsx
@@ -48,19 +48,15 @@ export const TextCard = ({
       {...root}
     >
       {image?.src && (
-        <Box mb={6}>
-          <AspectRatio
-            ratio={1}
-            position="relative"
-            width="50px"
-            overflow="hidden"
-            mb={3}
-          >
-            <Image src={image.src} alt={image?.alt ?? ''} fill />
-          </AspectRatio>
+        <Box mb={6} position="relative">
+          <Image
+            src={image.src}
+            alt={image?.alt ?? ''}
+            width={50}
+            height={50}
+          />
         </Box>
       )}
-
       {title?.children && (
         <Box
           textStyle={['Desktop/Default', null, 'Desktop/M']}


### PR DESCRIPTION
- Updated TextCard images to render in 50x50px. This fixes an issue of images being cut off by using the AspectRatio wrapper, but will now skew images. This can be later fine tuned by the content manager and developer what the preferred image aspect ratio is for their images in TextCards.

  - Before: 
![image](https://github.com/composable-com/composable-ui/assets/13950845/7b0cd6e3-3c9d-4292-9e9b-d0d8a920bb33)

  - After: 
 ![image](https://github.com/composable-com/composable-ui/assets/13950845/2bf8cca2-1f40-4d77-985a-74424263c75c)

- Updated Account Drawer spacing between components
  - Before:
![image](https://github.com/composable-com/composable-ui/assets/13950845/a44bd66c-b987-4fe1-9f6b-a93760d2df49)

  - After:
![image](https://github.com/composable-com/composable-ui/assets/13950845/913f492f-5473-42ea-be6c-6755a94a6b6d)
