### PR TITLE
feat: updated next.config.js for supporting remote images

### DIFF
--- a/composable-ui/next.config.js
+++ b/composable-ui/next.config.js
@@ -39,9 +39,13 @@ module.exports = () => {
       '@composable/ui',
     ],
     images: {
-      domains: ['loremflickr.com'],
-      formats: ['image/avif', 'image/webp'],
-      minimumCacheTTL: 60 * 60 * 24 * 30,
+      remotePatterns: [
+        {
+          protocol: 'https',
+          hostname: '*.example.com',
+          port: '',
+        },
+      ],
     },
     i18n: {
       locales: ['en-US'],


### PR DESCRIPTION
Composable-ui storefront was using a [deprecated pattern](https://nextjs.org/docs/app/api-reference/components/image#remotepatterns) for defining sources of remote images. This change brings the next.js.config file up to date with the latest pattern, which provides more control of specifying image sources from remote hosts. See the docs for [remotePatterns](https://nextjs.org/docs/app/api-reference/components/image#remotepatterns)
