### PR TITLE
fix: resolve sharp lib dependency issue in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:18-alpine
+FROM node:18-bookworm
+# For an in depth guide on configuring the base node image, see the official Next.js with-docker example here:
+# https://github.com/vercel/next.js/tree/canary/examples/with-docker
 
 RUN npm install -g pnpm
 


### PR DESCRIPTION
There is a library dependency issue error when building the docker image by executing `docker-compose up --build` in the root directory:

![docker-sharp-error](https://github.com/composable-com/composable-ui/assets/13950845/d3253e6a-2e4d-47bc-9c7c-3e311d4d482e)

This is due to node image `node:18-alpine` missing the required libraries to run `sharp`, which is needed by the [Next.js Image component](https://nextjs.org/docs/messages/install-sharp)

To resolve this, the Dockerfile is being updated to build from `node:18-bookworm`.

For an in depth guide on running Next.js in a Docker container, review the official Vercel example [with-docker](https://github.com/vercel/next.js/tree/canary/examples/with-docker) on how you can orchestrate building the container.